### PR TITLE
Modify run_after_commit to accept blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem 'after_commit_queue'
 
 ### Usage
 
-Include AfterCommitQueue module in your ActiveRecord model and you're ready to go.
+Include AfterCommitQueue module in your ActiveRecord model and you're ready to go. When registering a hook with run_after_commit you can supply either a method symbol or a block. No parameter is supplied when using the block form.
 
 ```ruby
 class Server < ActiveRecord::Base
@@ -41,7 +41,9 @@ class Server < ActiveRecord::Base
   end
 
   def schedule_stop
-    run_after_commit(:stop_server)
+    run_after_commit do
+      stop_server
+    end
   end
 
   def start_server; @started = true end

--- a/lib/after_commit_queue.rb
+++ b/lib/after_commit_queue.rb
@@ -10,15 +10,16 @@ module AfterCommitQueue
   # Protected: Is called as after_commit callback
   # runs methods from the queue and clears the queue afterwards
   def _run_after_commit_queue
-    _after_commit_queue.each do |method|
-      send(method)
+    _after_commit_queue.each do |action|
+      action.call
     end
     @after_commit_queue.clear
   end
 
   # Protected: Add method to after commit queue
-  def run_after_commit(method)
-    _after_commit_queue << method
+  def run_after_commit(method = nil, &block)
+    _after_commit_queue << Proc.new { self.send(method) } if method
+    _after_commit_queue << block if block
     true
   end
 

--- a/test/after_commit_queue_test.rb
+++ b/test/after_commit_queue_test.rb
@@ -16,6 +16,18 @@ class AfterCommitQueueTest < ActiveSupport::TestCase
     assert @server.started
   end
 
+  test "run blocks after transaction is committed" do
+    @server.start!
+    assert !@server.meditating
+
+    @server.transaction do
+      @server.crash!
+      assert !@server.meditating
+    end
+
+    assert @server.meditating
+  end
+
   test "clear queue after methods from are called" do
     @server.start!
     @server.started = false

--- a/test/dummy/app/models/server.rb
+++ b/test/dummy/app/models/server.rb
@@ -1,13 +1,16 @@
 class Server < ActiveRecord::Base
   include AfterCommitQueue
 
-  attr_accessor :started, :stopped
+  attr_accessor :started, :stopped, :meditating
 
   state_machine :state, :initial => :pending do
     after_transition :pending => :running, :do => :schedule_start
+    after_transition :running => :crashed, :do => :schedule_guru_meditation
     after_transition :running => :turned_off, :do => :schedule_stop
+
     event(:start) { transition :pending => :running }
     event(:stop) { transition :running => :turned_off }
+    event(:crash) { transition :running => :crashed }
   end
 
   def schedule_start
@@ -16,6 +19,12 @@ class Server < ActiveRecord::Base
 
   def schedule_stop
     run_after_commit(:stop_server)
+  end
+
+  def schedule_guru_meditation
+    run_after_commit do
+      @meditating = true
+    end
   end
 
   def start_server; @started = true end


### PR DESCRIPTION
Patch to run_after_commit so it accepts blocks in place of a method
