### PR TITLE
Clear queue after rollback

### DIFF
--- a/lib/after_commit_queue.rb
+++ b/lib/after_commit_queue.rb
@@ -3,6 +3,7 @@ module AfterCommitQueue
 
   included do
     after_commit :_run_after_commit_queue
+    after_rollback :_clear_after_commit_queue
   end
 
   protected
@@ -27,5 +28,9 @@ module AfterCommitQueue
   # Returns: Array with methods to run
   def _after_commit_queue
     @after_commit_queue ||= []
+  end
+
+  def _clear_after_commit_queue
+    @after_commit_queue.clear
   end
 end

--- a/test/after_commit_queue_test.rb
+++ b/test/after_commit_queue_test.rb
@@ -36,4 +36,17 @@ class AfterCommitQueueTest < ActiveSupport::TestCase
     assert !@server.started
     assert @server.stopped
   end
+
+  test "clears queue after rollback" do
+    assert !@server.started
+
+    Server.transaction do
+      @server.start!
+      assert !@server.started
+      raise ActiveRecord::Rollback
+    end
+    
+    assert @server.__send__(:_after_commit_queue).empty?
+    assert !@server.started
+  end
 end


### PR DESCRIPTION
I don't know if there's a convention for how to deal with objects after a rollback, but I think it makes sense to clear out the queue?
