### PR TITLE
Fix calling `clear` on nil when transaction is rolled back

### DIFF
--- a/lib/after_commit_queue.rb
+++ b/lib/after_commit_queue.rb
@@ -31,6 +31,6 @@ module AfterCommitQueue
   end
 
   def _clear_after_commit_queue
-    @after_commit_queue.clear
+    _after_commit_queue.clear
   end
 end

--- a/test/after_commit_queue_test.rb
+++ b/test/after_commit_queue_test.rb
@@ -45,8 +45,12 @@ class AfterCommitQueueTest < ActiveSupport::TestCase
       assert !@server.started
       raise ActiveRecord::Rollback
     end
-    
+
     assert @server.__send__(:_after_commit_queue).empty?
     assert !@server.started
+  end
+
+  test "clears queue even when no callback was enqueued" do
+    @server.rolledback!(false)
   end
 end


### PR DESCRIPTION
I have no idea why it fails for me. But might be something about nested transactions in rspec:

```
Caught NoMethodError: undefined method `clear' for nil:NilClass
    /Users/mikz/.rvm/gems/ruby-1.9.3-p374-railsexpress@3scale3/gems/after_commit_queue-1.0.1/lib/after_commit_queue.rb:34:in `_clear_after_commit_queue'
    /Users/mikz/.rvm/gems/ruby-1.9.3-p374-railsexpress@3scale3/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `_run__2618979648383371027__rollback__485157533732720751__callbacks'
    /Users/mikz/.rvm/gems/ruby-1.9.3-p374-railsexpress@3scale3/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `__run_callback'
    /Users/mikz/.rvm/gems/ruby-1.9.3-p374-railsexpress@3scale3/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in `_run_rollback_callbacks'
    /Users/mikz/.rvm/gems/ruby-1.9.3-p374-railsexpress@3scale3/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /Users/mikz/.rvm/gems/ruby-1.9.3-p374-railsexpress@3scale3/gems/activerecord-3.2.13/lib/active_record/transactions.rb:289:in `rolledback!'
    /Users/mikz/.rvm/gems/ruby-1.9.3-p374-railsexpress@3scale3/gems/activerecord-3.2.13/lib/active_record/connection_adapters/abstract/database_statements.rb:357:in `block in rollback_transaction_records'
```

So I've made patch to always initialize the array before clearing it. It prevents all calls on nil.
