### PR TITLE
Allow run_after_commit to be called from an observer

### DIFF
--- a/lib/after_commit_queue.rb
+++ b/lib/after_commit_queue.rb
@@ -6,6 +6,13 @@ module AfterCommitQueue
     after_rollback :_clear_after_commit_queue
   end
 
+  # Public: Add method to after commit queue
+  def run_after_commit(method = nil, &block)
+    _after_commit_queue << Proc.new { self.send(method) } if method
+    _after_commit_queue << block if block
+    true
+  end
+
   protected
 
   # Protected: Is called as after_commit callback
@@ -15,13 +22,6 @@ module AfterCommitQueue
       action.call
     end
     @after_commit_queue.clear
-  end
-
-  # Protected: Add method to after commit queue
-  def run_after_commit(method = nil, &block)
-    _after_commit_queue << Proc.new { self.send(method) } if method
-    _after_commit_queue << block if block
-    true
   end
 
   # Protected: Return after commit queue

--- a/lib/after_commit_queue.rb
+++ b/lib/after_commit_queue.rb
@@ -19,7 +19,7 @@ module AfterCommitQueue
   # runs methods from the queue and clears the queue afterwards
   def _run_after_commit_queue
     _after_commit_queue.each do |action|
-      action.call
+      self.instance_eval &action
     end
     @after_commit_queue.clear
   end

--- a/test/after_commit_queue_test.rb
+++ b/test/after_commit_queue_test.rb
@@ -28,6 +28,19 @@ class AfterCommitQueueTest < ActiveSupport::TestCase
     assert @server.meditating
   end
 
+  test "external observer changes state" do
+    @server.start!
+    @server.stop!
+    assert !@server.uninstalled
+
+    @server.transaction do
+      @server.uninstall!
+      assert !@server.uninstalled
+    end
+
+    assert @server.uninstalled
+  end
+  
   test "clear queue after methods from are called" do
     @server.start!
     @server.started = false

--- a/test/dummy/app/models/server.rb
+++ b/test/dummy/app/models/server.rb
@@ -1,7 +1,7 @@
 class Server < ActiveRecord::Base
   include AfterCommitQueue
 
-  attr_accessor :started, :stopped, :meditating
+  attr_accessor :started, :stopped, :meditating, :uninstalled
 
   state_machine :state, :initial => :pending do
     after_transition :pending => :running, :do => :schedule_start
@@ -11,6 +11,7 @@ class Server < ActiveRecord::Base
     event(:start) { transition :pending => :running }
     event(:stop) { transition :running => :turned_off }
     event(:crash) { transition :running => :crashed }
+    event(:uninstall) { transition :turned_off => :uninstalled }
   end
 
   def schedule_start

--- a/test/dummy/app/models/server_observer.rb
+++ b/test/dummy/app/models/server_observer.rb
@@ -1,0 +1,5 @@
+class ServerObserver < ActiveRecord::Observer
+  def after_transition_state_to_uninstalled(server, transition)
+    server.run_after_commit { @uninstalled = true }
+  end
+end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -19,7 +19,7 @@ module Dummy
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
 
     # Activate observers that should always be running.
-    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
+    config.active_record.observers = :server_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
This change makes the run_after_commit public, and evaluates the block in the context of the model instance so that this works.

I've added a test to the dummy app as well.
