### PR TITLE
Remove dependency on rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    after_commit_queue (1.1.0)
-      activesupport (>= 3.0)
+    after_commit_queue (1.2.0)
+      activerecord (>= 3.0)
       state_machine
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     after_commit_queue (1.1.0)
-      rails (>= 3.0)
+      activesupport (>= 3.0)
+      state_machine
 
 GEM
   remote: http://rubygems.org/
@@ -88,6 +89,7 @@ PLATFORMS
 
 DEPENDENCIES
   after_commit_queue!
+  rails (>= 3.0)
   rails-observers
   sqlite3
   state_machine

--- a/after_commit_queue.gemspec
+++ b/after_commit_queue.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "activesupport", ">= 3.0"
+  s.add_dependency "activerecord", ">= 3.0"
   s.add_dependency "state_machine"
 
   s.add_development_dependency "sqlite3"

--- a/after_commit_queue.gemspec
+++ b/after_commit_queue.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.0"
+  s.add_dependency "activesupport", ">= 3.0"
+  s.add_dependency "state_machine"
 
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "rails", ">= 3.0"
 end

--- a/lib/after_commit_queue/version.rb
+++ b/lib/after_commit_queue/version.rb
@@ -1,3 +1,3 @@
 module AfterCommitQueue
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
state_machine, as well as after_commit_queue are only utilizing methods from the 'activesupport' and 'activerecord' gems. As such, after_commit_queue should not be dependent on rails. This change allows somebody to utilize this gem in a rack application that uses activerecord without forcing that project to include Rails as well.
